### PR TITLE
api: fix typedefs to known length

### DIFF
--- a/common/inc/lx_api.h
+++ b/common/inc/lx_api.h
@@ -127,18 +127,18 @@ extern   "C" {
 #define VOID                                    void
 typedef char                                    CHAR;
 typedef char                                    BOOL;
-typedef unsigned char                           UCHAR;
-typedef int                                     INT;
-typedef unsigned int                            UINT;
-typedef long                                    LONG;
-typedef unsigned long                           ULONG;
-typedef short                                   SHORT;
-typedef unsigned short                          USHORT;
+typedef uint8_t                                 UCHAR;
+typedef int32_t                                 INT;
+typedef uint32_t                                UINT;
+typedef int32_t                                 LONG;
+typedef uint32_t                                ULONG;
+typedef int16_t                                 SHORT;
+typedef uint16_t                                USHORT;
 #endif
 
 #ifndef ULONG64_DEFINED
 #define ULONG64_DEFINED
-typedef unsigned long long                      ULONG64;
+typedef uint64_t                                ULONG64;
 #endif
 
 /* Define basic alignment type used in block and byte pool operations. This data type must


### PR DESCRIPTION
all internal ULONG compares are defined in 32b e.g. 
```
if (list_word == LX_NOR_PHYSICAL_SECTOR_FREE)
```
where
```
#define LX_NOR_PHYSICAL_SECTOR_FREE                 0xFFFFFFFF
```
this change maps internal types to known-length types from <stdint.h>