### PR TITLE
fix github levelx regression test action issue

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -22,4 +22,4 @@ jobs:
       pull-requests: write
       pages: write
       id-token: write
-    uses: azure-rtos/threadx/.github/workflows/regression_template.yml@master
+    uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master


### PR DESCRIPTION
fix github levelx regression test action issue

- update regression_test.yml

uses: azure-rtos/threadx/.github/workflows/regression_template.yml@master 
==>
uses: eclipse-threadx/threadx/.github/workflows/regression_template.yml@master