### PR TITLE
fix: "array out of bounds" error leading to memory corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Set up the project
 project(levelx

--- a/common/src/lx_nor_flash_extended_cache_enable.c
+++ b/common/src/lx_nor_flash_extended_cache_enable.c
@@ -290,7 +290,7 @@ ULONG   block_word;
     
     /* Loop through the memory supplied and assign to cache entries.  */
     i =  0;
-    while (cache_size >= LX_NOR_SECTOR_SIZE)
+    while ((cache_size >= LX_NOR_SECTOR_SIZE) && (i < LX_NOR_EXTENDED_CACHE_SIZE))
     {
     
         /* Setup this cache entry.  */
@@ -309,7 +309,7 @@ ULONG   block_word;
     }
     
     /* Save the number of cache entries.  */
-    if(i > LX_NOR_EXTENDED_CACHE_SIZE)
+    if(i == LX_NOR_EXTENDED_CACHE_SIZE)
     {
 
         nor_flash -> lx_nor_flash_extended_cache_entries =  LX_NOR_EXTENDED_CACHE_SIZE;


### PR DESCRIPTION
Fix description
----------------
add missing checks on the index of nor_flash -> lx_nor_flash_extended_cache[i]

Fixes Issue #58