### PR TITLE
Fix uninitialized mapped sector state in NOR erase block search

### DIFF
--- a/common/src/lx_nor_flash_next_block_to_erase_find.c
+++ b/common/src/lx_nor_flash_next_block_to_erase_find.c
@@ -103,7 +103,7 @@ ULONG   max_logical_sector;
 UINT    status;
 #endif
 UINT    obsolete_sectors_available;
-UINT    mapped_sectors_available;
+UINT    mapped_sectors_available = LX_FALSE;
 
 
     /* Setup the block word pointer to the first word of the search block.  */
@@ -171,9 +171,10 @@ UINT    mapped_sectors_available;
         if (erase_count > max_system_block_erase_count)
             max_system_block_erase_count =  erase_count;
 
-        /* Initialize the obsolete and mapped sector count available flags.  */
+        /* Initialize the mapped sector count and the obsolete/mapped sector count availability flags.  */
         obsolete_sectors_available =  LX_FALSE;
         mapped_sectors_available =  LX_FALSE;
+        mapped_sectors =  0;
 
 #ifdef LX_NOR_ENABLE_OBSOLETE_COUNT_CACHE
 
@@ -470,4 +471,3 @@ UINT    mapped_sectors_available;
     /* Return success.  */
     return(LX_SUCCESS);
 }
-


### PR DESCRIPTION
## Summary

Fix potentially uninitialized mapped sector state in `_lx_nor_flash_next_block_to_erase_find()`.

Depending on the control flow, the obsolete sector count may be obtained from the cache or block metadata without scanning the physical sector mapping table. In these cases, `mapped_sectors` was subsequently copied into candidate block information without being initialized for the current block.

Additionally, `mapped_sectors_available` was declared without an initial value and is checked after the block search loop. This caused compilers such as GCC to report `-Wmaybe-uninitialized` warnings, for example:

```text
warning: 'mapped_sectors_available' may be used uninitialized [-Wmaybe-uninitialized]
```

The change:

* initializes `mapped_sectors_available` to `LX_FALSE` at declaration;
* resets `mapped_sectors` to `0` for every block iteration;
* keeps the existing availability flag logic intact.

When the mapped sector count is unavailable, LevelX still computes the actual count for the selected erase block before returning it. The change therefore removes the compiler warnings and prevents stale or indeterminate intermediate values without changing the erase-block selection behavior.
