### PR TITLE
reclaim: fix uninitialized status when LX_DIRECT_READ is used

### DIFF
--- a/common/src/lx_nor_flash_block_reclaim.c
+++ b/common/src/lx_nor_flash_block_reclaim.c
@@ -453,7 +453,7 @@ UINT    status;
                         _lx_nor_flash_system_error(nor_flash, LX_SYSTEM_ALLOCATION_FAILED);
 
                         /* Return the error.  */
-                        return(status);
+                        return(LX_SYSTEM_ALLOCATION_FAILED);
                     }
 
                     /* Decrement the number of mapped sectors.  */


### PR DESCRIPTION
This PR re-submits the fix originally proposed in #21.

The original PR has been open for some time, and the original author appears to have run into issues with the Eclipse Contributor Agreement (ECA), preventing the contribution from moving forward.

The change itself is unchanged: when LX_DIRECT_READ is enabled, status may be uninitialized on this error path. Returning LX_SYSTEM_ALLOCATION_FAILED directly ensures that the reported error matches the preceding _lx_nor_flash_system_error() call and avoids returning an undefined value.

Original PR: #21

Thanks to @jiri-novotny for identifying the issue and proposing the original fix.